### PR TITLE
HTTP/SOCKS4 proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ Options:
   -s HOST, --server=HOST
                         Attack to server IP.
   -y FILENAME, --proxy_list=FILENAME
-                        File with sock5 proxies in ip:port:username:password or ip:port line format.
+                        File with proxies in ip:port:username:password or ip:port line format.
                         Proxies will be ignored in udp attack!
+  -k PROXY_TYPE, --proxy_type=PROXY_TYPE (default socks5)
+                        Type of proxy to work with. Supported types: socks5, socks4, http.
   -c STATE, --health_check=STATE (default: 1)
                         Controls health check availability. Turn on: 1, turn off: 0.
   -e HTTP_METHOD, --http_method=HTTP_METHOD (default: GET)

--- a/ripper/arg_parser.py
+++ b/ripper/arg_parser.py
@@ -35,7 +35,10 @@ def parser_add_options(parser: OptionParser) -> None:
                       help='Attack to server IP')
     parser.add_option('-y', '--proxy_list',
                       dest='proxy_list',
-                      help='File with sock5 proxies in ip:port:username:password line format. Proxies will be ignored in udp attack!')
+                      help='File with proxies in ip:port:username:password line format. Proxies will be ignored in udp attack!')
+    parser.add_option('-k', '--proxy_type',
+                      dest='proxy_type', type='str', default='socks5',
+                      help='Type of proxy to work with. Supported types: socks5, socks4, http. Default: socks5')
     parser.add_option('-c', '--health_check',
                       dest='health_check', type='int', default=1,
                       help='Controls health check availability. Turn on: 1, turn off: 0. Default: 1')

--- a/ripper/common.py
+++ b/ripper/common.py
@@ -101,7 +101,9 @@ def get_country_by_ipv4(host_ip: str) -> str:
 
     country = GEOIP_NOT_DEFINED
     try:
-        response_body = urllib.request.urlopen(f'https://ipinfo.io/{host_ip}', timeout=1).read().decode('utf8')
+        # Sometimes ends up in HTTP Error 429: Too Many Requests
+        # TODO support multiple services
+        response_body = urllib.request.urlopen(f'https://ipinfo.io/{host_ip}', timeout=3).read().decode('utf8')
         response_data = json.loads(response_body)
         country = response_data['country']
     except:

--- a/ripper/context.py
+++ b/ripper/context.py
@@ -11,7 +11,6 @@ from ripper.common import is_ipv4, strip_lines
 from ripper.constants import DEFAULT_CURRENT_IP_VALUE, MIN_SCREEN_WIDTH
 from ripper.proxy_manager import ProxyManager
 from ripper.socket_manager import SocketManager
-from ripper.proxy import read_proxy_list
 
 
 def get_headers_dict(base_headers: list[str]):
@@ -290,8 +289,7 @@ def init_context(_ctx: Context, args):
     _ctx.is_health_check = False if args[0].health_check == 0 else True
 
     if args[0].proxy_list and _ctx.attack_method != 'udp':
-        proxy_list = read_proxy_list(args[0].proxy_list)
-        _ctx.proxy_manager.set_proxy_list(proxy_list)
+        _ctx.proxy_manager.update_proxy_list_from_file(args[0].proxy_list)
 
     if args[0].http_method:
         _ctx.http_method = args[0].http_method.upper()

--- a/ripper/context.py
+++ b/ripper/context.py
@@ -289,6 +289,7 @@ def init_context(_ctx: Context, args):
     _ctx.is_health_check = False if args[0].health_check == 0 else True
 
     if args[0].proxy_list and _ctx.attack_method != 'udp':
+        _ctx.proxy_manager.set_proxy_type(args[0].proxy_type)
         _ctx.proxy_manager.update_proxy_list_from_file(args[0].proxy_list)
 
     if args[0].http_method:

--- a/ripper/proxy.py
+++ b/ripper/proxy.py
@@ -6,7 +6,7 @@ from typing import List
 from ripper.common import readfile, ns2s
 
 
-class Socks5Proxy:
+class Proxy:
     def __init__(self, host: str, port: int, username: str = None, password: str = None, rdns: bool = True):
         self.host = host
         self.port = int(port)
@@ -53,7 +53,7 @@ class Socks5Proxy:
             return f'SOCKS5:{self.host}:{self.port}:{self.rdns}'
 
     def __eq__(self, other):
-        if not isinstance(other, Socks5Proxy):
+        if not isinstance(other, Sock5Proxy):
             # don't attempt to compare against unrelated types
             return NotImplemented
 
@@ -63,6 +63,11 @@ class Socks5Proxy:
             and self.password == other.password \
             and self.rdns == other.rdns
 
+    def validate(self):
+        raise NotImplementedError
+
+
+class Socks5Proxy(Proxy):
     def validate(self):
         try:
             http_socket = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
@@ -75,7 +80,7 @@ class Socks5Proxy:
         return True
 
 
-def read_proxy_list(filename: str) -> List[Socks5Proxy]:
+def read_proxy_list(filename: str) -> List[Proxy]:
     proxy_list = []
     lines = readfile(filename)
     for line in lines:
@@ -83,6 +88,6 @@ def read_proxy_list(filename: str) -> List[Socks5Proxy]:
         args = line.strip().split(':')
         if len(args) not in [2, 4]:
             raise ValueError(args)
-        proxy = Socks5Proxy(*args)
+        proxy = Proxy(*args)
         proxy_list.append(proxy)
     return proxy_list

--- a/ripper/proxy.py
+++ b/ripper/proxy.py
@@ -6,7 +6,7 @@ from typing import List
 from ripper.common import readfile, ns2s
 
 
-class Sock5Proxy:
+class Socks5Proxy:
     def __init__(self, host: str, port: int, username: str = None, password: str = None, rdns: bool = True):
         self.host = host
         self.port = int(port)
@@ -53,7 +53,7 @@ class Sock5Proxy:
             return f'SOCKS5:{self.host}:{self.port}:{self.rdns}'
 
     def __eq__(self, other):
-        if not isinstance(other, Sock5Proxy):
+        if not isinstance(other, Socks5Proxy):
             # don't attempt to compare against unrelated types
             return NotImplemented
 
@@ -75,7 +75,7 @@ class Sock5Proxy:
         return True
 
 
-def read_proxy_list(filename: str) -> List[Sock5Proxy]:
+def read_proxy_list(filename: str) -> List[Socks5Proxy]:
     proxy_list = []
     lines = readfile(filename)
     for line in lines:
@@ -83,6 +83,6 @@ def read_proxy_list(filename: str) -> List[Sock5Proxy]:
         args = line.strip().split(':')
         if len(args) not in [2, 4]:
             raise ValueError(args)
-        proxy = Sock5Proxy(*args)
+        proxy = Socks5Proxy(*args)
         proxy_list.append(proxy)
     return proxy_list

--- a/ripper/proxy.py
+++ b/ripper/proxy.py
@@ -1,18 +1,25 @@
 import socket
 import socks
 import time
-from typing import List
+from enum import Enum
 
-from ripper.common import readfile, ns2s
+from ripper.common import ns2s
+
+
+class ProxyType(Enum):
+    SOCKS4 = 'SOCKS4'
+    SOCKS5 = 'SOCKS5'
+    HTTP = 'HTTP'
 
 
 class Proxy:
-    def __init__(self, host: str, port: int, username: str = None, password: str = None, rdns: bool = True):
+    def __init__(self, host: str, port: int, username: str = None, password: str = None, proxy_type: ProxyType = ProxyType.SOCKS5, rdns: bool = True):
         self.host = host
         self.port = int(port)
         self.username = username
         self.password = password
         self.rdns = rdns
+        self.proxy_type = proxy_type
         
         self.last_success_time = 0
         self.success_cnt = 0
@@ -53,7 +60,7 @@ class Proxy:
             return f'SOCKS5:{self.host}:{self.port}:{self.rdns}'
 
     def __eq__(self, other):
-        if not isinstance(other, Sock5Proxy):
+        if not isinstance(other, Proxy):
             # don't attempt to compare against unrelated types
             return NotImplemented
 
@@ -64,11 +71,6 @@ class Proxy:
             and self.rdns == other.rdns
 
     def validate(self):
-        raise NotImplementedError
-
-
-class Socks5Proxy(Proxy):
-    def validate(self):
         try:
             http_socket = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
             self.decorate_socket(http_socket)
@@ -78,16 +80,3 @@ class Socks5Proxy(Proxy):
         except:
             return False
         return True
-
-
-def read_proxy_list(filename: str) -> List[Proxy]:
-    proxy_list = []
-    lines = readfile(filename)
-    for line in lines:
-        # ip:port:username:password or ip:port
-        args = line.strip().split(':')
-        if len(args) not in [2, 4]:
-            raise ValueError(args)
-        proxy = Proxy(*args)
-        proxy_list.append(proxy)
-    return proxy_list

--- a/ripper/proxy_manager.py
+++ b/ripper/proxy_manager.py
@@ -1,7 +1,7 @@
 import random
 import threading
 
-from ripper.proxy import Sock5Proxy
+from ripper.proxy import Socks5Proxy
 from ripper.constants import PROXY_MAX_FAILURE_RATIO, PROXY_MIN_VALIDATION_REQUESTS
 
 lock = threading.Lock()
@@ -10,19 +10,19 @@ lock = threading.Lock()
 class ProxyManager:
     """Manager for proxy collection."""
 
-    proxy_list: list[Sock5Proxy] = []
+    proxy_list: list[Socks5Proxy] = []
     """Active proxies."""
     proxy_list_initial_len: int = 0
     """Count of proxies during the last application."""
     __proxy_extract_counter: int = 0
     """Vacuum operation is called automatically on every PROXY_MIN_VALIDATION_REQUESTS proxy extractions"""
 
-    def set_proxy_list(self, proxy_list: list[Sock5Proxy]):
+    def set_proxy_list(self, proxy_list: list[Socks5Proxy]):
         self.proxy_list = proxy_list
         self.proxy_list_initial_len = len(proxy_list)
 
     # TODO prioritize faster proxies
-    def get_random_proxy(self) -> Sock5Proxy:
+    def get_random_proxy(self) -> Socks5Proxy:
         self.__proxy_extract_counter += 1
         if self.__proxy_extract_counter % PROXY_MIN_VALIDATION_REQUESTS == 0:
             self.vacuum()
@@ -30,7 +30,7 @@ class ProxyManager:
             return None
         return random.choice(self.proxy_list)
 
-    def find_proxy_index(self, proxy: Sock5Proxy) -> int:
+    def find_proxy_index(self, proxy: Socks5Proxy) -> int:
         """returns -1 if not found"""
         try:
             return self.proxy_list.index(proxy)
@@ -38,19 +38,19 @@ class ProxyManager:
         except:
             return -1
 
-    def __delete_proxy(self, proxy: Sock5Proxy) -> bool:
+    def __delete_proxy(self, proxy: Socks5Proxy) -> bool:
         index = self.find_proxy_index(proxy)
         if index >= 0:
             self.proxy_list.pop(index)
         return index >= 0
 
-    def delete_proxy_sync(self, proxy: Sock5Proxy) -> bool:
+    def delete_proxy_sync(self, proxy: Socks5Proxy) -> bool:
         lock.acquire()
         is_deleted = self.__delete_proxy(proxy)
         lock.release()
         return is_deleted
 
-    def __validate_proxy(self, proxy: Sock5Proxy) -> bool:
+    def __validate_proxy(self, proxy: Socks5Proxy) -> bool:
         total_cnt = proxy.success_cnt + proxy.failure_cnt
         if total_cnt < PROXY_MIN_VALIDATION_REQUESTS:
             return True

--- a/ripper/proxy_manager.py
+++ b/ripper/proxy_manager.py
@@ -1,7 +1,9 @@
 import random
 import threading
+from typing import List
 
-from ripper.proxy import Socks5Proxy
+from ripper.common import readfile
+from ripper.proxy import Proxy, ProxyType
 from ripper.constants import PROXY_MAX_FAILURE_RATIO, PROXY_MIN_VALIDATION_REQUESTS
 
 lock = threading.Lock()
@@ -10,19 +12,21 @@ lock = threading.Lock()
 class ProxyManager:
     """Manager for proxy collection."""
 
-    proxy_list: list[Socks5Proxy] = []
+    proxy_list: list[Proxy] = []
     """Active proxies."""
     proxy_list_initial_len: int = 0
     """Count of proxies during the last application."""
     __proxy_extract_counter: int = 0
     """Vacuum operation is called automatically on every PROXY_MIN_VALIDATION_REQUESTS proxy extractions"""
+    proxy_type: ProxyType = ProxyType.SOCKS5
+    """Type of proxy (SOCKS5, SOCKS4, HTTP)"""
 
-    def set_proxy_list(self, proxy_list: list[Socks5Proxy]):
+    def set_proxy_list(self, proxy_list: list[Proxy]):
         self.proxy_list = proxy_list
         self.proxy_list_initial_len = len(proxy_list)
 
     # TODO prioritize faster proxies
-    def get_random_proxy(self) -> Socks5Proxy:
+    def get_random_proxy(self) -> Proxy:
         self.__proxy_extract_counter += 1
         if self.__proxy_extract_counter % PROXY_MIN_VALIDATION_REQUESTS == 0:
             self.vacuum()
@@ -30,7 +34,7 @@ class ProxyManager:
             return None
         return random.choice(self.proxy_list)
 
-    def find_proxy_index(self, proxy: Socks5Proxy) -> int:
+    def find_proxy_index(self, proxy: Proxy) -> int:
         """returns -1 if not found"""
         try:
             return self.proxy_list.index(proxy)
@@ -38,19 +42,19 @@ class ProxyManager:
         except:
             return -1
 
-    def __delete_proxy(self, proxy: Socks5Proxy) -> bool:
+    def __delete_proxy(self, proxy: Proxy) -> bool:
         index = self.find_proxy_index(proxy)
         if index >= 0:
             self.proxy_list.pop(index)
         return index >= 0
 
-    def delete_proxy_sync(self, proxy: Socks5Proxy) -> bool:
+    def delete_proxy_sync(self, proxy: Proxy) -> bool:
         lock.acquire()
         is_deleted = self.__delete_proxy(proxy)
         lock.release()
         return is_deleted
 
-    def __validate_proxy(self, proxy: Socks5Proxy) -> bool:
+    def __validate_proxy(self, proxy: Proxy) -> bool:
         total_cnt = proxy.success_cnt + proxy.failure_cnt
         if total_cnt < PROXY_MIN_VALIDATION_REQUESTS:
             return True
@@ -64,3 +68,16 @@ class ProxyManager:
         if cnt > 0:
             self.proxy_list = new_proxy_list
         return cnt
+
+    def update_proxy_list_from_file(self, filename: str) -> List[Proxy]:
+        proxy_list = []
+        lines = readfile(filename)
+        for line in lines:
+            # ip:port:username:password or ip:port
+            args = line.strip().split(':')
+            if len(args) not in [2, 4]:
+                raise ValueError(args)
+            proxy = Proxy(*args, proxy_type=self.proxy_type)
+            proxy_list.append(proxy)
+        self.set_proxy_list(proxy_list)
+        return proxy_list

--- a/ripper/proxy_manager.py
+++ b/ripper/proxy_manager.py
@@ -21,6 +21,17 @@ class ProxyManager:
     proxy_type: ProxyType = ProxyType.SOCKS5
     """Type of proxy (SOCKS5, SOCKS4, HTTP)"""
 
+    def set_proxy_type(self, proxy_type: str):
+        proxy_type_lc = proxy_type.lower()
+        if proxy_type_lc == 'socks5':
+            self.proxy_type = ProxyType.SOCKS5
+        elif proxy_type_lc == 'socks4':
+            self.proxy_type = ProxyType.SOCKS4
+        elif proxy_type_lc == 'http':
+            self.proxy_type = ProxyType.HTTP
+        else:
+            self.proxy_type = None
+
     def set_proxy_list(self, proxy_list: list[Proxy]):
         self.proxy_list = proxy_list
         self.proxy_list_initial_len = len(proxy_list)

--- a/ripper/services.py
+++ b/ripper/services.py
@@ -10,7 +10,7 @@ from ripper.attacks import *
 from ripper.constants import *
 from ripper.common import get_current_ip, format_dt, ns2s
 from ripper.health_check import fetch_host_statuses
-from ripper.proxy import Socks5Proxy
+from ripper.proxy import Proxy
 
 _ctx = Context()
 
@@ -133,7 +133,7 @@ def update_host_statuses(_ctx: Context):
         _ctx.fetching_host_statuses_in_progress = False
 
 
-def connect_host(_ctx: Context, proxy: Socks5Proxy = None) -> bool:
+def connect_host(_ctx: Context, proxy: Proxy = None) -> bool:
     _ctx.Statistic.connect.set_state_in_progress()
     try:
         sock = _ctx.sock_manager.create_tcp_socket(proxy)

--- a/ripper/services.py
+++ b/ripper/services.py
@@ -10,7 +10,7 @@ from ripper.attacks import *
 from ripper.constants import *
 from ripper.common import get_current_ip, format_dt, ns2s
 from ripper.health_check import fetch_host_statuses
-from ripper.proxy import Sock5Proxy
+from ripper.proxy import Socks5Proxy
 
 _ctx = Context()
 
@@ -133,7 +133,7 @@ def update_host_statuses(_ctx: Context):
         _ctx.fetching_host_statuses_in_progress = False
 
 
-def connect_host(_ctx: Context, proxy: Sock5Proxy = None) -> bool:
+def connect_host(_ctx: Context, proxy: Socks5Proxy = None) -> bool:
     _ctx.Statistic.connect.set_state_in_progress()
     try:
         sock = _ctx.sock_manager.create_tcp_socket(proxy)

--- a/ripper/services.py
+++ b/ripper/services.py
@@ -176,11 +176,15 @@ def validate_input(args) -> bool:
         return False
 
     if args.http_method and args.http_method.lower() not in ('get', 'post', 'head', 'put', 'delete', 'trace', 'connect', 'options', 'patch'):
-        print(f'Wrong http method type. Possible options: get, post, head, put, delete, trace, connect, options, patch.')
+        print(f'Wrong HTTP method type. Possible options: get, post, head, put, delete, trace, connect, options, patch.')
         return False
 
     if args.http_path and not args.http_path.startswith('/'):
-        print(f'Http path should start with /.')
+        print(f'HTTP path should start with /.')
+        return False
+
+    if args.proxy_type and args.proxy_type.lower() not in ('http', 'socks5', 'socks4'):
+        print(f'Wrong proxy type. Possible options: http, socks5, socks4.')
         return False
 
     return True

--- a/ripper/socket_manager.py
+++ b/ripper/socket_manager.py
@@ -1,7 +1,7 @@
 import socks
 import socket
 
-from ripper.proxy import Socks5Proxy
+from ripper.proxy import Proxy
 
 
 class SocketManager:
@@ -21,7 +21,7 @@ class SocketManager:
         udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         return udp_socket
 
-    def create_tcp_socket(self, proxy: Socks5Proxy = None) -> socket:
+    def create_tcp_socket(self, proxy: Proxy = None) -> socket:
         """Returns tcp socket."""
         tcp_socket = socks.socksocket(
             socket.AF_INET, socket.SOCK_STREAM, socket.SOL_TCP)

--- a/ripper/socket_manager.py
+++ b/ripper/socket_manager.py
@@ -1,7 +1,7 @@
 import socks
 import socket
 
-from ripper.proxy import Sock5Proxy
+from ripper.proxy import Socks5Proxy
 
 
 class SocketManager:
@@ -21,7 +21,7 @@ class SocketManager:
         udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         return udp_socket
 
-    def create_tcp_socket(self, proxy: Sock5Proxy = None) -> socket:
+    def create_tcp_socket(self, proxy: Socks5Proxy = None) -> socket:
         """Returns tcp socket."""
         tcp_socket = socks.socksocket(
             socket.AF_INET, socket.SOCK_STREAM, socket.SOL_TCP)

--- a/ripper/statistic.py
+++ b/ripper/statistic.py
@@ -72,7 +72,8 @@ def collect_stats(_ctx: Context) -> list[Row]:
         Row('Load Method',               _ctx.attack_method.upper(), end_section=True),
         # ===================================
         Row('Threads',                   f'{_ctx.threads}'),
-        Row('Proxies count',             f'[cyan]{len(_ctx.proxy_manager.proxy_list)} / {_ctx.proxy_manager.proxy_list_initial_len}', visible=is_proxy_list),
+        Row('Proxies Count',             f'[cyan]{len(_ctx.proxy_manager.proxy_list)} / {_ctx.proxy_manager.proxy_list_initial_len}', visible=is_proxy_list),
+        Row('Proxies Type',              f'[cyan]{_ctx.proxy_manager.proxy_type.value}', visible=is_proxy_list),
         Row('vCPU Count',                f'{_ctx.cpu_count}'),
         Row('Socket Timeout (seconds)',  f'{_ctx.sock_manager.socket_timeout}'),
         Row('Random Packet Length',      f'{_ctx.random_packet_len}{max_length}', end_section=True),

--- a/ripper/urllib_x.py
+++ b/ripper/urllib_x.py
@@ -4,7 +4,7 @@ import socks
 import socket
 from urllib.parse import urlparse
 
-from ripper.proxy import Sock5Proxy
+from ripper.proxy import Socks5Proxy
 
 
 ###############################################
@@ -64,7 +64,7 @@ class Response:
         self.full_response = full_response
 
 
-def create_http_socket(proxy: Sock5Proxy = None, socket_timeout: int = None) -> socket:
+def create_http_socket(proxy: Socks5Proxy = None, socket_timeout: int = None) -> socket:
     """Returns http socket."""
     http_socket = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
     proxy.decorate_socket(http_socket) if proxy is not None else 0
@@ -73,7 +73,7 @@ def create_http_socket(proxy: Sock5Proxy = None, socket_timeout: int = None) -> 
     return http_socket
 
 
-def http_request(url: str, headers={}, extra_data=None, read_resp_size=32, http_method: str = None, proxy: Sock5Proxy = None, socket_timeout: int = None):
+def http_request(url: str, headers={}, extra_data=None, read_resp_size=32, http_method: str = None, proxy: Socks5Proxy = None, socket_timeout: int = None):
     url_data = urlparse(url)
     hostname = url_data.hostname
     scheme = url_data.scheme

--- a/ripper/urllib_x.py
+++ b/ripper/urllib_x.py
@@ -4,7 +4,7 @@ import socks
 import socket
 from urllib.parse import urlparse
 
-from ripper.proxy import Socks5Proxy
+from ripper.proxy import Proxy
 
 
 ###############################################
@@ -64,7 +64,7 @@ class Response:
         self.full_response = full_response
 
 
-def create_http_socket(proxy: Socks5Proxy = None, socket_timeout: int = None) -> socket:
+def create_http_socket(proxy: Proxy = None, socket_timeout: int = None) -> socket:
     """Returns http socket."""
     http_socket = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
     proxy.decorate_socket(http_socket) if proxy is not None else 0
@@ -73,7 +73,7 @@ def create_http_socket(proxy: Socks5Proxy = None, socket_timeout: int = None) ->
     return http_socket
 
 
-def http_request(url: str, headers={}, extra_data=None, read_resp_size=32, http_method: str = None, proxy: Socks5Proxy = None, socket_timeout: int = None):
+def http_request(url: str, headers={}, extra_data=None, read_resp_size=32, http_method: str = None, proxy: Proxy = None, socket_timeout: int = None):
     url_data = urlparse(url)
     hostname = url_data.hostname
     scheme = url_data.scheme


### PR DESCRIPTION
Added support for HTTP and SOCKS4 proxy.

```
  -y FILENAME, --proxy_list=FILENAME
                        File with proxies in ip:port:username:password or ip:port line format.
                        Proxies will be ignored in udp attack!
  -k PROXY_TYPE, --proxy_type=PROXY_TYPE (default socks5)
                        Type of proxy to work with. Supported types: socks5, socks4, http.
```